### PR TITLE
digital-inverter-openlane: fix openlane env

### DIFF
--- a/digital-inverter-openlane.ipynb
+++ b/digital-inverter-openlane.ipynb
@@ -144,8 +144,6 @@
         "\n",
         "set ::env(DIODE_INSERTION_STRATEGY) 3\n",
         "\n",
-        "# disable version checks because we use conda packaged versions\n",
-        "set ::env(TEST_MISMATCHES) none\n",
         "# disable klayout because of https://github.com/hdl/conda-eda/issues/175\n",
         "set ::env(RUN_KLAYOUT) 0\n",
         "# disable CVC because of https://github.com/hdl/conda-eda/issues/174\n",
@@ -186,6 +184,7 @@
             "env: OPENLANE_ROOT=/content/OpenLane\n",
             "env: PATH=/content/conda-env/bin:/opt/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/tools/node/bin:/tools/google-cloud-sdk/bin:/content/OpenLane:/content/OpenLane/scripts\n",
             "env: OPENLANE_LOCAL_INSTALL=1\n",
+            "env: TEST_MISMATCHES=none\n",
             "OpenLane 57f3f21d6e1d0403a88d7a7973f7447597aae160\r\n",
             "All rights reserved. (c) 2020-2022 Efabless Corporation and contributors.\r\n",
             "Available under the Apache License, version 2.0. See the LICENSE file for more details.\r\n",
@@ -320,6 +319,7 @@
         "%env OPENLANE_ROOT={OPENLANE_ROOT}\n",
         "%env PATH={PATH}:{OPENLANE_ROOT}:{OPENLANE_ROOT}/scripts\n",
         "%env OPENLANE_LOCAL_INSTALL=1\n",
+        "%env TEST_MISMATCHES=none\n",
         "!flow.tcl -design ."
       ]
     },


### PR DESCRIPTION
With https://github.com/The-OpenROAD-Project/OpenLane/pull/1297 we need to make sure `TEST_MISSMATCHES` is set before the configuration is loaded.

@donn @mithro @PiotrZierhoffer can you review?

TESTED=https://colab.research.google.com/github/proppy/silicon-notebooks/blob/fix-env/digital-inverter-openlane.ipynb