### PR TITLE
remove '' from bash command

### DIFF
--- a/xls-adder-openlane.ipynb
+++ b/xls-adder-openlane.ipynb
@@ -2281,7 +2281,7 @@
     {
       "cell_type": "code",
       "source": [
-        "%%bash -c 'cat > adder.x; interpreter_main adder.x'\n",
+        "%%bash -c cat > adder.x; interpreter_main adder.x\n",
         "\n",
         "pub fn adder(in1: u1, in2: u1) -> u2 {\n",
         "  let sum: u2 = in1 as u2 + in2 as u2;\n",


### PR DESCRIPTION
Removed '' from bash command of Write and test DSLX module cell. 
Originally, `%%bash -c 'cat > adder.x; interpreter_main adder.x'` was throwing CalledProcessError in Google colab.
Changed it to `%%bash -c 'cat > adder.x; interpreter_main adder.x`, now runs correctly.